### PR TITLE
Fix BBDEHEADER deadlock, add QA and support padded DATAFIELD

### DIFF
--- a/lib/bbdeheader_bb_impl.cc
+++ b/lib/bbdeheader_bb_impl.cc
@@ -336,6 +336,7 @@ namespace gr {
 
       const unsigned int n_bbframes = noutput_items / (max_dfl / 8);
       for (unsigned int i = 0; i < n_bbframes; i++) {
+        // Check the BBHEADER integrity
         check = check_crc8_bits(in, BB_HEADER_LENGTH_BITS);
         if (dvb_standard == STANDARD_DVBS2) {
           mode = INPUTMODE_NORMAL;
@@ -359,186 +360,214 @@ namespace gr {
             check = FALSE;
           }
         }
+
         if (check != TRUE) {
           synched = FALSE;
           printf("Baseband header crc failed.\n");
           in += kbch;
+          continue;
+        }
+
+        // Parse the BBHEADER
+        h->ts_gs = *in++ << 1;
+        h->ts_gs |= *in++;
+        h->sis_mis = *in++;
+        h->ccm_acm = *in++;
+        h->issyi = *in++;
+        h->npd = *in++;
+        h->ro = *in++ << 1;
+        h->ro |= *in++;
+        h->isi = 0;
+        if (h->sis_mis == 0) {
+          for (int n = 7; n >= 0; n--) {
+            h->isi |= *in++ << n;
+          }
         }
         else {
-          h->ts_gs = *in++ << 1;
-          h->ts_gs |= *in++;
-          h->sis_mis = *in++;
-          h->ccm_acm = *in++;
-          h->issyi = *in++;
-          h->npd = *in++;
-          h->ro = *in++ << 1;
-          h->ro |= *in++;
-          h->isi = 0;
-          if (h->sis_mis == 0) {
-            for (int n = 7; n >= 0; n--) {
-              h->isi |= *in++ << n;
-            }
-          }
-          else {
-            in += 8;
-          }
-          h->upl = 0;
-          for (int n = 15; n >= 0; n--) {
-            h->upl |= *in++ << n;
-          }
-          h->dfl = 0;
-          for (int n = 15; n >= 0; n--) {
-            h->dfl |= *in++ << n;
-          }
-          h->sync = 0;
-          for (int n = 7; n >= 0; n--) {
-            h->sync |= *in++ << n;
-          }
-          h->syncd = 0;
-          for (int n = 15; n >= 0; n--) {
-            h->syncd |= *in++ << n;
-          }
           in += 8;
-          if (synched == FALSE) {
-            printf("Baseband header resynchronizing.\n");
-            if (mode == INPUTMODE_NORMAL) {
-              in += h->syncd + 8;
-              h->dfl -= h->syncd + 8;
-            }
-            else {
-              in += h->syncd;
-              h->dfl -= h->syncd;
-            }
-            count = 0;
-            synched = TRUE;
-            index = 0;
-            spanning = FALSE;
-            distance = h->syncd;
-          }
+        }
+        h->upl = 0;
+        for (int n = 15; n >= 0; n--) {
+          h->upl |= *in++ << n;
+        }
+        h->dfl = 0;
+        for (int n = 15; n >= 0; n--) {
+          h->dfl |= *in++ << n;
+        }
+        h->sync = 0;
+        for (int n = 7; n >= 0; n--) {
+          h->sync |= *in++ << n;
+        }
+        h->syncd = 0;
+        for (int n = 15; n >= 0; n--) {
+          h->syncd |= *in++ << n;
+        }
+        in += 8; // Skip the last byte (CRC-8), processed in the beginning.
+
+        // Validate the DFL and the SYNCD fields of the BBHEADER
+        if (h->dfl > max_dfl) {
+          synched = FALSE;
+          printf("Baseband header invalid (dfl > kbch - 80).\n");
+          in += max_dfl;
+          continue;
+        }
+
+        if (h->dfl % 8 != 0) {
+          synched = FALSE;
+          printf("Baseband header invalid (dfl not a multiple of 8).\n");
+          in += max_dfl;
+          continue;
+        }
+
+        if (h->syncd > h->dfl) {
+          synched = FALSE;
+          printf("Baseband header invalid (syncd > dfl).\n");
+          in += max_dfl;
+          continue;
+        }
+
+        // Skip the initial SYNCD bits of the DATAFIELD if re-synchronizing
+        if (synched == FALSE) {
+          printf("Baseband header resynchronizing.\n");
           if (mode == INPUTMODE_NORMAL) {
-            while (h->dfl) {
-              if (count == 0) {
-                crc = 0;
-                if (index == TRANSPORT_PACKET_LENGTH) {
-                  for (int j = 0; j < TRANSPORT_PACKET_LENGTH; j++) {
-                    *out++ = packet[j];
-                    produced++;
-                  }
-                  index = 0;
-                  spanning = FALSE;
-                }
-                if (h->dfl < TRANSPORT_PACKET_LENGTH * 8) {
-                  index = 0;
-                  packet[index++] = 0x47;
-                  spanning = TRUE;
-                }
-                else {
-                  *out++ = 0x47;
-                  produced++;
-                  tei = out;
-                }
-                count++;
-                if (check == TRUE) {
-                  if (distance != (unsigned int)h->syncd) {
-                    synched = FALSE;
-                  }
-                  check = FALSE;
-                }
-              }
-              else if (count == TRANSPORT_PACKET_LENGTH) {
-                tmp = 0;
-                for (int n = 7; n >= 0; n--) {
-                  tmp |= *in++ << n;
-                }
-                if (tmp != crc) {
-                  errors++;
-                  if (spanning) {
-                    packet[1] |= TRANSPORT_ERROR_INDICATOR;
-                  }
-                  else {
-                    *tei |= TRANSPORT_ERROR_INDICATOR;
-                  }
-                }
-                count = 0;
-                h->dfl -= 8;
-                if (h->dfl == 0) {
-                  distance = (TRANSPORT_PACKET_LENGTH - 1) * 8;
-                }
-              }
-              if (h->dfl >= 8 && count > 0) {
-                tmp = 0;
-                for (int n = 7; n >= 0; n--) {
-                  tmp |= *in++ << n;
-                  distance++;
-                }
-                crc = crc_tab[tmp ^ crc];
-                if (spanning == TRUE) {
-                  packet[index++] = tmp;
-                }
-                else {
-                  *out++ = tmp;
-                  produced++;
-                }
-                count++;
-                h->dfl -= 8;
-                if (h->dfl == 0) {
-                  distance = 0;
-                }
-              }
-            }
+            in += h->syncd + 8;
+            h->dfl -= h->syncd + 8;
           }
           else {
-            while (h->dfl) {
-              if (count == 0) {
-                if (index == TRANSPORT_PACKET_LENGTH) {
-                  for (int j = 0; j < TRANSPORT_PACKET_LENGTH; j++) {
-                    *out++ = packet[j];
-                    produced++;
-                  }
-                  index = 0;
-                  spanning = FALSE;
-                }
-                if (h->dfl < (TRANSPORT_PACKET_LENGTH - 1) * 8) {
-                  index = 0;
-                  packet[index++] = 0x47;
-                  spanning = TRUE;
-                }
-                else {
-                  *out++ = 0x47;
+            in += h->syncd;
+            h->dfl -= h->syncd;
+          }
+          count = 0;
+          synched = TRUE;
+          index = 0;
+          spanning = FALSE;
+          distance = h->syncd;
+        }
+
+        // Process the DATAFIELD
+        if (mode == INPUTMODE_NORMAL) {
+          while (h->dfl) {
+            if (count == 0) {
+              crc = 0;
+              if (index == TRANSPORT_PACKET_LENGTH) {
+                for (int j = 0; j < TRANSPORT_PACKET_LENGTH; j++) {
+                  *out++ = packet[j];
                   produced++;
                 }
-                count++;
-                if (check == TRUE) {
-                  if (distance != (unsigned int)h->syncd) {
-                    synched = FALSE;
-                  }
-                  check = FALSE;
-                }
+                index = 0;
+                spanning = FALSE;
               }
-              else if (count == TRANSPORT_PACKET_LENGTH) {
-                count = 0;
-                if (h->dfl == 0) {
-                  distance = 0;
-                }
+              if (h->dfl < TRANSPORT_PACKET_LENGTH * 8) {
+                index = 0;
+                packet[index++] = 0x47;
+                spanning = TRUE;
               }
-              if (h->dfl >= 8 && count > 0) {
-                tmp = 0;
-                for (int n = 7; n >= 0; n--) {
-                  tmp |= *in++ << n;
-                  distance++;
+              else {
+                *out++ = 0x47;
+                produced++;
+                tei = out;
+              }
+              count++;
+              if (check == TRUE) {
+                if (distance != (unsigned int)h->syncd) {
+                  synched = FALSE;
                 }
-                if (spanning == TRUE) {
-                  packet[index++] = tmp;
+                check = FALSE;
+              }
+            }
+            else if (count == TRANSPORT_PACKET_LENGTH) {
+              tmp = 0;
+              for (int n = 7; n >= 0; n--) {
+                tmp |= *in++ << n;
+              }
+              if (tmp != crc) {
+                errors++;
+                if (spanning) {
+                  packet[1] |= TRANSPORT_ERROR_INDICATOR;
                 }
                 else {
-                  *out++ = tmp;
+                  *tei |= TRANSPORT_ERROR_INDICATOR;
+                }
+              }
+              count = 0;
+              h->dfl -= 8;
+              if (h->dfl == 0) {
+                distance = (TRANSPORT_PACKET_LENGTH - 1) * 8;
+              }
+            }
+            if (h->dfl >= 8 && count > 0) {
+              tmp = 0;
+              for (int n = 7; n >= 0; n--) {
+                tmp |= *in++ << n;
+                distance++;
+              }
+              crc = crc_tab[tmp ^ crc];
+              if (spanning == TRUE) {
+                packet[index++] = tmp;
+              }
+              else {
+                *out++ = tmp;
+                produced++;
+              }
+              count++;
+              h->dfl -= 8;
+              if (h->dfl == 0) {
+                distance = 0;
+              }
+            }
+          }
+        }
+        else {
+          while (h->dfl) {
+            if (count == 0) {
+              if (index == TRANSPORT_PACKET_LENGTH) {
+                for (int j = 0; j < TRANSPORT_PACKET_LENGTH; j++) {
+                  *out++ = packet[j];
                   produced++;
                 }
-                count++;
-                h->dfl -= 8;
-                if (h->dfl == 0) {
-                  distance = 0;
+                index = 0;
+                spanning = FALSE;
+              }
+              if (h->dfl < (TRANSPORT_PACKET_LENGTH - 1) * 8) {
+                index = 0;
+                packet[index++] = 0x47;
+                spanning = TRUE;
+              }
+              else {
+                *out++ = 0x47;
+                produced++;
+              }
+              count++;
+              if (check == TRUE) {
+                if (distance != (unsigned int)h->syncd) {
+                  synched = FALSE;
                 }
+                check = FALSE;
+              }
+            }
+            else if (count == TRANSPORT_PACKET_LENGTH) {
+              count = 0;
+              if (h->dfl == 0) {
+                distance = 0;
+              }
+            }
+            if (h->dfl >= 8 && count > 0) {
+              tmp = 0;
+              for (int n = 7; n >= 0; n--) {
+                tmp |= *in++ << n;
+                distance++;
+              }
+              if (spanning == TRUE) {
+                packet[index++] = tmp;
+              }
+              else {
+                *out++ = tmp;
+                produced++;
+              }
+              count++;
+              h->dfl -= 8;
+              if (h->dfl == 0) {
+                distance = 0;
               }
             }
           }

--- a/lib/bbdeheader_bb_impl.h
+++ b/lib/bbdeheader_bb_impl.h
@@ -32,10 +32,10 @@ typedef struct{
     int npd;
     int ro;
     int isi;
-    int upl;
-    int dfl;
+    unsigned int upl;
+    unsigned int dfl;
     int sync;
-    int syncd;
+    unsigned int syncd;
 }BBHeader;
 
 typedef struct{

--- a/lib/bbdeheader_bb_impl.h
+++ b/lib/bbdeheader_bb_impl.h
@@ -49,6 +49,7 @@ namespace gr {
     {
      private:
       unsigned int kbch;
+      unsigned int max_dfl;
       unsigned int dvb_standard;
       unsigned int count;
       unsigned int synched;

--- a/lib/bbdeheader_bb_impl.h
+++ b/lib/bbdeheader_bb_impl.h
@@ -51,6 +51,7 @@ namespace gr {
       unsigned int kbch;
       unsigned int max_dfl;
       unsigned int dvb_standard;
+      unsigned int df_remaining;
       unsigned int count;
       unsigned int synched;
       unsigned char crc;

--- a/lib/dvb_defines.h
+++ b/lib/dvb_defines.h
@@ -24,7 +24,7 @@
 #define TRUE 1
 #define FALSE 0
 
-#define BB_HEADER_LENGTH_BITS 72
+#define BB_HEADER_LENGTH_BITS 80
 
 // BB HEADER fields
 #define TS_GS_TRANSPORT 3

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -31,3 +31,4 @@ GR_PYTHON_INSTALL(
 include(GrTest)
 
 set(GR_TEST_TARGET_DEPS gnuradio-dvbs2rx)
+GR_ADD_TEST(qa_bbdeheader_bb ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/qa_bbdeheader_bb.py)

--- a/python/qa_bbdeheader_bb.py
+++ b/python/qa_bbdeheader_bb.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019-2021 Blockstream
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+import struct
+
+import numpy as np
+from gnuradio import gr, gr_unittest
+from gnuradio import blocks
+from math import ceil, floor
+try:
+    from dvbs2rx import bbdeheader_bb, STANDARD_DVBS2, FECFRAME_NORMAL, C1_4
+except ImportError:
+    import os
+    import sys
+    dirname, filename = os.path.split(os.path.abspath(__file__))
+    sys.path.append(os.path.join(dirname, "bindings"))
+    from dvbs2rx import bbdeheader_bb, STANDARD_DVBS2, FECFRAME_NORMAL, C1_4
+
+DVBS2_GEN_POLY = '111010101'  # x^8 + x^7 + x^6 + x^4 + x^2 +1
+BBHEADER_NO_CRC_FMT = "!BBHHBH"  # BBHEADER format excluding the CRC field
+BBHEADER_LEN = 10  # BBHEADER length in bytes
+UPL_BYTES = 188  # User packet length in bytes
+SYNC_BYTE = b'\x47'
+
+
+def crc8(in_bytes, polynomial_bitstring=DVBS2_GEN_POLY):
+    """Compute the CRC-8 of an input bytes sequence
+
+    Args:
+        in_bytes (bytes): Input sequence of bytes.
+        polynomial_bitstring (str, optional): Generator polynomial as a bit
+            string. Defaults to DVBS2_GEN_POLY.
+
+    Returns:
+        bytes: Resulting CRC-8 as a unit-length bytes object.
+    """
+    L = len(polynomial_bitstring)
+    in_bits = np.unpackbits(np.frombuffer(in_bytes, dtype=np.uint8))
+    gen_poly = np.array(list(map(int, polynomial_bitstring)), dtype=np.uint8)
+
+    dividend = np.concatenate([in_bits, np.zeros(L - 1, dtype=np.uint8)])
+    for i in range(len(in_bits)):
+        if (dividend[i]):
+            dividend[i:i + L] = np.bitwise_xor(dividend[i:i + L], gen_poly)
+
+    remainder = dividend[len(in_bits):]
+    return np.packbits(remainder).tobytes()
+
+
+def gen_up():
+    """Generate a random user packet (UP)
+
+    Returns:
+        bytes: Generated UP.
+    """
+    payload = np.random.bytes(UPL_BYTES - 4)
+    return SYNC_BYTE + bytes(3) + payload
+
+
+def gen_up_stream(n_ups):
+    """Generate a stream of UPs
+
+    Args:
+        n_ups (int): Number of UPs to generate.
+
+    Returns:
+        bytes: Stream of UPs.
+    """
+    stream = bytearray()
+    for i in range(n_ups):
+        stream += gen_up()
+    return bytes(stream)
+
+
+def replace_sync_with_crc(original_stream):
+    """Replace the sync byte on each UP with the CRC8 of the previous packet
+
+    Args:
+        original_stream (bytes): Original stream of UPs with the sync byte.
+
+    Returns:
+        (bytes): CRC8-modified UP stream.
+    """
+    stream = bytearray(original_stream)
+    n_ups = int(len(stream) / UPL_BYTES)
+    crc = None
+    for i in range(n_ups):
+        up_start = i * UPL_BYTES
+        up_end = (i + 1) * UPL_BYTES
+        if (crc is not None):
+            stream[up_start] = int.from_bytes(crc, byteorder='big')
+        crc = crc8(stream[up_start + 1:up_end])
+    return bytes(stream)
+
+
+def gen_bbheader(kbch, syncd, dfl=None):
+    """Generate a BBHEADER
+
+    Args:
+        kbch (int): BCH message length.
+        syncd (int): Distance in bits between the start of the DFL and the
+            start of the first full UP.
+        dfl (optional, int): DATAFIELD length in bits. When undefined, it is
+            set to the maximum length equal to "kbch - 80".
+
+    Returns:
+        bytes: Generated BBHEADER.
+    """
+    ts_gs = 3  # MPEG-TS
+    sis_mis = 1  # SIS
+    ccm_acm = 1  # CCM
+    issyi = 0  # not active
+    npd = 0  # not active
+    ro = 2  # rolloff=0.2
+    matype_1 = ts_gs << 6 | sis_mis << 5 | ccm_acm << 4 | issyi << 3 \
+        | npd << 2 | ro
+    matype_2 = 0  # reserved if SIS/MIS=1 (i.e., in SIS mode)
+    upl = UPL_BYTES * 8  # MPEG TS length in bits
+    if (dfl is None):
+        dfl = kbch - 80  # use the maximum DATAFIELD length
+
+    # Generate the BBHEADER excluding the CRC8
+    bbheader_no_crc = struct.pack(BBHEADER_NO_CRC_FMT, matype_1, matype_2, upl,
+                                  dfl, int("47", 16), syncd)
+    # Append the CRC8
+    return bbheader_no_crc + crc8(bbheader_no_crc)
+
+
+def gen_bbframe_stream(kbch, n_frames, up_stream):
+    """Generate stream of unscrambled BBFRAMEs
+
+    Args:
+        kbch (int): BCH input (uncoded) message length in bits.
+        n_frames (int): Number of BBFRAMEs to generate.
+        up_stream (bytes): Stream of UPs to fill in the DATAFIELDs.
+
+    Returns:
+        bytes: Generated stream of BBFRAMEs.
+    """
+
+    dfl_bytes = int((kbch - 80) / 8)
+    assert (len(up_stream) >= n_frames * dfl_bytes)
+
+    # CRC-8 Encoder: replace the sync field of each UP with the CRC-8 of the
+    # preceding packet.
+    modified_up_stream = replace_sync_with_crc(up_stream)
+
+    # BBFRAME stream:
+    stream = bytearray()
+    syncd = 0
+    offset = 0
+    for i in range(n_frames):
+        # Fill the BBHEADER
+        stream += gen_bbheader(kbch, syncd)
+        # Fill the payload with UPs
+        stream += modified_up_stream[offset:(offset + dfl_bytes)]
+        # The last UP may not be complete:
+        partial_up_len = (offset + dfl_bytes) % UPL_BYTES
+        # The remaining part of the UP will come in the next BBFRAME
+        remaining_up_len = UPL_BYTES - partial_up_len
+        # Update the corresponding syncd info (in bits, not bytes)
+        syncd = remaining_up_len * 8
+        # Go to the next DATAFIELD
+        offset += dfl_bytes
+    return stream
+
+
+class qa_bbdeheader_bb(gr_unittest.TestCase):
+    def setUp(self):
+        self.tb = gr.top_block()
+
+    def _set_stream_len_params(self, kbch, n_bbframes):
+        """Set up some common stream length parameters
+
+        Args:
+            kbch (int): BCH uncoded message (dataword) length.
+            n_bbframes (int): Number of BBFRAMEs generated on the test.
+        """
+        assert (n_bbframes % 2 == 0), \
+            "n_bbframes must be even to match bbdeheader output multiple"
+
+        # Bytes per DATAFIELD
+        self.dfl_bytes = dfl_bytes = int((kbch - 80) / 8)
+
+        # Total number of full or partial UPs within n_bbframes.
+        self.n_ups = int(ceil(n_bbframes * dfl_bytes / UPL_BYTES))
+
+        # Total number of full UPs within n_bbframes.
+        self.n_full_ups = int(floor(n_bbframes * dfl_bytes / UPL_BYTES))
+
+    def _set_up_flowgraph(self, in_stream):
+        """Set up the flowgraph
+
+        Vector Source -> Packed-to-Unpacked -> BBDEHEADER -> Vector Sink
+
+        Args:
+            in_stream (bytes): Input stream to feed into the vector source.
+        """
+        src = blocks.vector_source_b(tuple(in_stream))
+        unpack = blocks.packed_to_unpacked_bb(1, gr.GR_MSB_FIRST)
+        bbdeheader = bbdeheader_bb(STANDARD_DVBS2, FECFRAME_NORMAL, C1_4)
+        self.sink = blocks.vector_sink_b()
+        self.tb.connect(src, unpack, bbdeheader, self.sink)
+
+    def _assert_up_stream(self, up_stream, n_discarded_bbframes=0):
+        """Assert the output contains the UPs from the non-discarded BBFRAMEs
+
+        Args:
+            up_stream (bytes): Original UP bytes sequence spanning the BBFRAME
+                stream generated on the test case.
+            n_discarded_bbframes (int, optional): Number of BBFRAMES discarded
+                in the beginning of the BBFRAME stream. Defaults to 0.
+        """
+        # The expected output starts at the first full UP available after the
+        # discarded BBFRAMEs.
+        n_discarded_ups = int(
+            ceil(n_discarded_bbframes * self.dfl_bytes / UPL_BYTES))
+        i_start = n_discarded_ups * UPL_BYTES
+        # It ends at the last full UP available on the last BBFRAME.
+        i_end = self.n_full_ups * UPL_BYTES
+        # Check
+        expected_out = list(up_stream[i_start:i_end])
+        observed_out = self.sink.data()
+        self.assertListEqual(expected_out, observed_out)
+
+    def test_successful_deframing(self):
+        """Test successful deframing of consecutive BBFRAMEs
+        """
+        # Parameters
+        kbch = 16008  # QPSK 1/4 with normal fecframe
+        n_bbframes = 10  # Number of BBFRAMEs to generate
+        self._set_stream_len_params(kbch, n_bbframes)
+
+        # Generate the stream of UPs and the corresponding stream of BBFRAMEs
+        up_stream = gen_up_stream(self.n_ups)
+        bbframe_stream = gen_bbframe_stream(kbch, n_bbframes, up_stream)
+
+        # Run the flowgraph and check results
+        self._set_up_flowgraph(bbframe_stream)
+        self.tb.run()
+        self._assert_up_stream(up_stream)
+
+    def test_bbheader_crc_error(self):
+        """Test processing of a BBFRAME with an invalid BBHEADER CRC
+        """
+        # Parameters
+        kbch = 16008  # QPSK 1/4 with normal fecframe
+        n_bbframes = 2  # Number of BBFRAMEs to generate
+        self._set_stream_len_params(kbch, n_bbframes)
+
+        # Generate the stream of UPs and the corresponding stream of BBFRAMEs
+        up_stream = gen_up_stream(self.n_ups)
+        bbframe_stream = gen_bbframe_stream(kbch, n_bbframes, up_stream)
+
+        # Corrupt the CRC checksum of the first BBHEADER
+        corrupt_stream = bytearray(bbframe_stream)
+        corrupt_stream[9] ^= 255
+
+        # Run the flowgraph
+        self._set_up_flowgraph(corrupt_stream)
+        self.tb.run()
+
+        # The first BBFRAME (with the CRC error) should be discarded
+        self._assert_up_stream(up_stream, n_discarded_bbframes=1)
+
+
+if __name__ == '__main__':
+    gr_unittest.run(qa_bbdeheader_bb)


### PR DESCRIPTION
This PR contains three commits, summarized below:

1. A review of the bbdeheader block's output multiple, which also introduces Python unit tests for the bbdeheader block.
2. A fix for deadlocks that can occur when invalid DFL/SYNCD values pass the CRC check.
3. Support for padded DATAFIELDs (with length `< kbch -80`).

The second patch (801b901) has a slightly ugly diff due to an indentation change. Hence, I'd recommend reviewing it manually with the following command to ignore space changes (option `-b`):

```
git diff 16e152b 801b901 -b
```

Also, it's worth mentioning that the second patch (801b901) solves a problem that I've observed multiple times in practice when experimenting with `gr-dvbs2rx` under low SNR conditions.

Lastly, I have tried to come up with `.clang-format` file that results in a similar format as what you had before. Hopefully, I didn't break the coding style. If you have a specific `.clang-format` file to share, let me know. Alternatively, if there isn't one, I can help to add the format adopted by GNU Radio and update the code base accordingly (on another PR), if you agree.

